### PR TITLE
refactor(api/garden): standardize GardenController conventions

### DIFF
--- a/apps/api/src/garden/garden.controller.ts
+++ b/apps/api/src/garden/garden.controller.ts
@@ -1,8 +1,8 @@
-import { Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { GardenService } from './garden.service';
 import { Garden } from 'generated/prisma/client';
 import { AuthGuard } from '@nestjs/passport';
-import { RequestUser } from 'src/auth/types/requsetUser.types';
+import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
 
 @Controller('gardens')
 @UseGuards(AuthGuard('jwt'))
@@ -10,18 +10,12 @@ export class GardenController {
   constructor(private readonly gardenService: GardenService) {}
 
   @Get()
-  async findByActive(
-    @Req() req: Request & { user: RequestUser }, // TODO: create custom decorator
-  ): Promise<Garden> {
-    const userId = req.user.id;
+  async findByActive(@CurrentUser('id') userId: string): Promise<Garden> {
     return await this.gardenService.getActive(userId);
   }
 
   @Post('reset')
-  async reset(
-    @Req() req: Request & { user: RequestUser }, // TODO: create custom decorator
-  ): Promise<Garden> {
-    const userId = req.user.id;
+  async reset(@CurrentUser('id') userId: string): Promise<Garden> {
     return await this.gardenService.reset(userId);
   }
 }

--- a/apps/api/src/garden/garden.controller.ts
+++ b/apps/api/src/garden/garden.controller.ts
@@ -5,11 +5,11 @@ import { AuthGuard } from '@nestjs/passport';
 import { RequestUser } from 'src/auth/types/requsetUser.types';
 
 @Controller('garden')
+@UseGuards(AuthGuard('jwt'))
 export class GardenController {
   constructor(private readonly gardenService: GardenService) {}
 
   @Get('active')
-  @UseGuards(AuthGuard('jwt'))
   async findByActive(
     @Req() req: Request & { user: RequestUser }, // TODO: create custom decorator
   ): Promise<Garden> {
@@ -18,7 +18,6 @@ export class GardenController {
   }
 
   @Post('reset')
-  @UseGuards(AuthGuard('jwt'))
   async reset(
     @Req() req: Request & { user: RequestUser }, // TODO: create custom decorator
   ): Promise<Garden> {

--- a/apps/api/src/garden/garden.controller.ts
+++ b/apps/api/src/garden/garden.controller.ts
@@ -4,12 +4,12 @@ import { Garden } from 'generated/prisma/client';
 import { AuthGuard } from '@nestjs/passport';
 import { RequestUser } from 'src/auth/types/requsetUser.types';
 
-@Controller('garden')
+@Controller('gardens')
 @UseGuards(AuthGuard('jwt'))
 export class GardenController {
   constructor(private readonly gardenService: GardenService) {}
 
-  @Get('active')
+  @Get()
   async findByActive(
     @Req() req: Request & { user: RequestUser }, // TODO: create custom decorator
   ): Promise<Garden> {


### PR DESCRIPTION
## 概要
<!-- このPRで何をしたか1〜2文で -->
GardenController のパス名・認証処理を SeedController と同じ規約に統一した。
/todos・/seeds と同様に認証済みユーザーのアクティブ Garden を暗黙的に返す。

## 変更内容
- `@Controller('garden')` → `@Controller('gardens')`
- `GET /gardens/active` → `GET /gardens`（`/todos`・`/seeds` と一貫性を持たせる）
- `@UseGuards(AuthGuard('jwt'))` をメソッドレベルからクラスレベルに移動
- `@Req()` → `@CurrentUser('id')` に置き換え

## テスト
<!-- 動作確認した内容・テストコマンド -->
- [x] GET /gardens が正しく動作することを Insomnia で確認
- [x] POST /gardens/reset が正しく動作することを Insomnia で確認


## レビューポイント
<!-- レビュアー（未来の自分）に見てほしい箇所 -->
`GET /gardens/active` → `GET /gardens` の設計変更。
`/active` はフィルター条件（状態）であり REST 的にはパスに含めるべきでない。
認証済みユーザーに対して active Garden は常に1件のため暗黙的フィルタリングとして扱う。

## 関連
closes #17 