### PR TITLE
docs(contributing): fix outdated API URL examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -472,9 +472,8 @@ PascalCase。ロール（役割）を suffix として付与する。
 
 ```
 GET  /seeds
-GET  /seeds/active
 POST /seeds/:id/plant
-GET  /gardens/active
+GET  /gardens
 POST /gardens/reset
 GET  /plant-nodes
 ```


### PR DESCRIPTION
## 概要
<!-- このPRで何をしたか1〜2文で -->
CONTRIBUTING.mdに残っていた古いURL例を更新した。

## 変更内容
- `GET /gardens/active` → `GET /gardens`
- `GET /seeds/active` 削除

## テスト
<!-- 動作確認した内容・テストコマンド -->
- [x] CONTRIBUTING.md の API URL 例が実装と一致していること

## レビューポイント
<!-- レビュアー（未来の自分）に見てほしい箇所 -->

## 関連
closes #19 
