### PR TITLE
タイトル: feat(shared): sync plant types with prisma schema

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@algarden/shared": "*",
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.2",

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -38,7 +38,7 @@ enum TodoScore {
 }
 
 enum MutationType {
-  OCTAHEDGON // 八面体
+  OCTAHEDRON // 八面体
   RADIAL // 放射
 }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@algarden/shared": "*",
     "@tailwindcss/vite": "^4.2.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/packages/shared/src/types/plant.ts
+++ b/packages/shared/src/types/plant.ts
@@ -8,12 +8,16 @@ export interface PlantNodeData {
   id: string;
   hue: number;
   size: number;
-  angle: number;
-  length: number;
   depth: number;
+  angle: number | null;
+  length: number | null;
+  mutationType: MutationType | null;
+  mutationProgress: number;
+  mutationBlueprint: unknown | null;
+  canSpawn: boolean;
   parentId: string | null;
-  plantId: string;
   todoId: string | null;
+  plantId: string;
   createdAt: string;
 }
 

--- a/packages/shared/src/types/plant.ts
+++ b/packages/shared/src/types/plant.ts
@@ -28,4 +28,13 @@ export interface PlantData {
   seedId: string;
   gardenId: string;
   plantNodes: PlantNodeData[];
+  plantEdges: PlantEdgeData[];
+}
+
+export interface PlantEdgeData {
+  id: string;
+  plantId: string;
+  fromId: string;
+  toId: string;
+  createdAt: string;
 }

--- a/packages/shared/src/types/plant.ts
+++ b/packages/shared/src/types/plant.ts
@@ -1,6 +1,6 @@
 export type GrowthStage = 'SPROUT' | 'YOUNG' | 'MATURE' | 'BLOOM';
 
-export type SeedType = 'DFS';
+export type SeedType = 'TENDRIL';
 
 export interface PlantNodeData {
   id: string;

--- a/packages/shared/src/types/plant.ts
+++ b/packages/shared/src/types/plant.ts
@@ -2,6 +2,8 @@ export type GrowthStage = 'SPROUT' | 'YOUNG' | 'MATURE' | 'BLOOM';
 
 export type SeedType = 'TENDRIL';
 
+export type MutationType = 'OCTAHEDRON' | 'RADIAL';
+
 export interface PlantNodeData {
   id: string;
   hue: number;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## 概要
<!-- このPRで何をしたか1〜2文で -->
これからweb部分を作っていくにあたって、api側と型を共有して使えるようにする枠組みを作る。

## 変更内容
- `SeedType` を `'DFS'` → `'TENDRIL'` に変更
- `MutationType` type を追加（`'OCTAHEDRON' | 'RADIAL'`）
- `PlantNodeData` に mutation fields を追加（`mutationType`, `mutationProgress`, `mutationBlueprint`, `canSpawn`）、`angle`/`length` を `number | null` に変更
- `PlantEdgeData` interface を新規追加
- `PlantData` に `plantEdges: PlantEdgeData[]` を追加
- `packages/shared/tsconfig.json` を追加
- api・web の `package.json` に `@algarden/shared` を依存追加

## テスト
<!-- 動作確認した内容・テストコマンド -->
- [x] `packages/shared` で `tsc --noEmit` が通ること

## レビューポイント
<!-- レビュアー（未来の自分）に見てほしい箇所 -->

## 関連
closes #25
