### PR TITLE
feat(api/plant): scaffold PlantService

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -4,9 +4,10 @@ import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
 import { GardenModule } from './garden/garden.module';
 import { SeedModule } from './seed/seed.module';
+import { PlantModule } from './plant/plant.module';
 
 @Module({
-  imports: [PrismaModule, TodoModule, AuthModule, GardenModule, SeedModule],
+  imports: [PrismaModule, TodoModule, AuthModule, GardenModule, SeedModule, PlantModule],
   controllers: [],
   providers: [],
 })

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,7 +7,14 @@ import { SeedModule } from './seed/seed.module';
 import { PlantModule } from './plant/plant.module';
 
 @Module({
-  imports: [PrismaModule, TodoModule, AuthModule, GardenModule, SeedModule, PlantModule],
+  imports: [
+    PrismaModule,
+    TodoModule,
+    AuthModule,
+    GardenModule,
+    SeedModule,
+    PlantModule,
+  ],
   controllers: [],
   providers: [],
 })

--- a/apps/api/src/plant/plant.controller.spec.ts
+++ b/apps/api/src/plant/plant.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PlantController } from './plant.controller';
+import { PlantService } from './plant.service';
+
+describe('PlantController', () => {
+  let controller: PlantController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PlantController],
+      providers: [PlantService],
+    }).compile();
+
+    controller = module.get<PlantController>(PlantController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/api/src/plant/plant.controller.ts
+++ b/apps/api/src/plant/plant.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { PlantService } from './plant.service';
+
+@Controller('plant')
+export class PlantController {
+  constructor(private readonly plantService: PlantService) {}
+}

--- a/apps/api/src/plant/plant.module.ts
+++ b/apps/api/src/plant/plant.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PlantService } from './plant.service';
+import { PlantController } from './plant.controller';
+
+@Module({
+  controllers: [PlantController],
+  providers: [PlantService],
+})
+export class PlantModule {}

--- a/apps/api/src/plant/plant.module.ts
+++ b/apps/api/src/plant/plant.module.ts
@@ -5,5 +5,6 @@ import { PlantController } from './plant.controller';
 @Module({
   controllers: [PlantController],
   providers: [PlantService],
+  exports: [PlantService],
 })
 export class PlantModule {}

--- a/apps/api/src/plant/plant.service.spec.ts
+++ b/apps/api/src/plant/plant.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PlantService } from './plant.service';
+
+describe('PlantService', () => {
+  let service: PlantService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PlantService],
+    }).compile();
+
+    service = module.get<PlantService>(PlantService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/api/src/plant/plant.service.ts
+++ b/apps/api/src/plant/plant.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PlantService {}


### PR DESCRIPTION
## 概要
PlantService・PlantModule を新規作成し、成長ロジックを担うモジュールの骨格を作る。
`complete()` リファクタおよび通常成長実装の前提となる基盤。

## 変更内容
- `apps/api/src/plant/` に PlantService・PlantModule・Controller を作成（空実装）
- `AppModule` に PlantModule を登録
- `PlantModule` から PlantService を export し、他モジュールへの DI を可能にする

## テスト
<!-- 動作確認した内容・テストコマンド -->
- [x] `tsc --noEmit` が通ること
- [x] `pnpm dev` 起動時にビルドエラーがないこと

## レビューポイント
<!-- レビュアー（未来の自分）に見てほしい箇所 -->
- `plant.module.ts` の `exports` により TodoModule からの inject が可能になっているが、TodoModule 側への import 追加は次のIssueで行う

## 関連
closes #29
