### PR TITLE
refactor(api): split plant growth into PlantService

### DIFF
--- a/apps/api/src/plant/plant.service.ts
+++ b/apps/api/src/plant/plant.service.ts
@@ -1,4 +1,87 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { PlantNode } from 'generated/prisma/client';
+import { CreatedNode, PlantWithNode } from './types/plant.types';
 
 @Injectable()
-export class PlantService {}
+export class PlantService {
+  /**
+   * 指定された範囲内のランダムな小数を生成する
+   *
+   * @param {number} min - 最小値(含む)
+   * @param {number} max - 最大値(含む)
+   * @returns {number} min以上max以下のランダムな小数
+   * @throws {Error} minがmaxより大きい場合
+   */
+  private random(min: number, max: number): number {
+    if (min > max) {
+      throw new Error('最小値は最大値以下である必要があります');
+    }
+    return Math.random() * (max - min) + min;
+  }
+
+  /**
+   * 指定された個数の子ノードをランダムな親から生成する
+   *
+   * @param {number} count - 生成するノード数
+   * @param {PlantWithNode} selectPlant - ノードを追加するPlant
+   * @param {string} todoId - ノードの生成元となるTodoのid
+   * @returns {CreatedNode[]} 生成したノード配列
+   */
+  generateNode(
+    count: number,
+    selectPlant: PlantWithNode,
+    todoId: string,
+  ): CreatedNode[] {
+    const MIN_HUE = 80;
+    const BASE_HUE = 120;
+    const HUE_DECAY_PER_DEPTH = 4;
+    const MIN_SIZE = 3;
+    const MIN_SIZE_RATIO = 0.65;
+    const MAX_SIZE_RATIO = 0.88;
+    const MIN_LENGTH = 5;
+    const MAX_LENGTH = 50;
+    const MIN_LENGTH_RATIO = 0.8;
+    const MAX_LENGTH_RATIO = 1.1;
+
+    const createdNodes: CreatedNode[] = [];
+
+    for (let i = 0; i < count; i++) {
+      const nodeIndex: number = Math.floor(
+        Math.random() * selectPlant.plantNodes.length,
+      );
+      const parentNode: PlantNode = selectPlant.plantNodes[nodeIndex];
+
+      if (!parentNode) {
+        throw new BadRequestException('親ノードが見つかりません。');
+      }
+
+      // ルートノードを親ノードとして生成する場合
+      const parentNodeLength =
+        parentNode.length === null ? MAX_LENGTH : parentNode.length;
+
+      // 子ノードのパラメータは親から継承し、深さに応じて減衰させる
+      const childNode: CreatedNode = {
+        hue: Math.max(
+          MIN_HUE,
+          BASE_HUE - parentNode.depth * HUE_DECAY_PER_DEPTH,
+        ),
+        size: Math.max(
+          MIN_SIZE,
+          parentNode.size * this.random(MIN_SIZE_RATIO, MAX_SIZE_RATIO),
+        ),
+        length: Math.max(
+          MIN_LENGTH,
+          parentNodeLength * this.random(MIN_LENGTH_RATIO, MAX_LENGTH_RATIO),
+        ),
+        depth: parentNode.depth + 1,
+        parentId: parentNode.id,
+        plantId: selectPlant.id,
+        todoId,
+      };
+
+      createdNodes.push(childNode);
+    }
+
+    return createdNodes;
+  }
+}

--- a/apps/api/src/plant/plant.service.ts
+++ b/apps/api/src/plant/plant.service.ts
@@ -1,6 +1,10 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { PlantNode } from 'generated/prisma/client';
-import { CreatedNode, PlantWithNode } from './types/plant.types';
+import { GrowthStage, Plant, PlantNode } from 'generated/prisma/client';
+import {
+  CreatedNode,
+  GrowthStageResult,
+  PlantWithNode,
+} from './types/plant.types';
 
 @Injectable()
 export class PlantService {
@@ -83,5 +87,32 @@ export class PlantService {
     }
 
     return createdNodes;
+  }
+
+  /**
+   * 追加ノード数をもとにPlantの現在の成長段階と昇格有無を算出する
+   *
+   * @param {Plant} selectPlant - 対象Plant
+   * @param {number} addNodeCnt - 追加するノード数
+   * @returns {GrowthStageResult} 現在の成長段階と昇格フラグ
+   */
+  calcGrowthStage(selectPlant: Plant, addNodeCnt: number): GrowthStageResult {
+    const curNodeCnt = selectPlant.nodeCount + addNodeCnt;
+
+    const curStage: GrowthStage =
+      curNodeCnt <= 5
+        ? GrowthStage.SPROUT
+        : curNodeCnt <= 15
+          ? GrowthStage.YOUNG
+          : curNodeCnt <= 30
+            ? GrowthStage.MATURE
+            : GrowthStage.BLOOM;
+
+    const isPromotion: boolean = selectPlant.growthStage !== curStage;
+
+    return {
+      curStage,
+      isPromotion,
+    };
   }
 }

--- a/apps/api/src/plant/types/plant.types.ts
+++ b/apps/api/src/plant/types/plant.types.ts
@@ -1,4 +1,4 @@
-import { Prisma } from 'generated/prisma/client';
+import { GrowthStage, Prisma } from 'generated/prisma/client';
 
 export type CreatedNode = {
   hue: number;
@@ -13,3 +13,8 @@ export type CreatedNode = {
 export type PlantWithNode = Prisma.PlantGetPayload<{
   include: { plantNodes: true };
 }>;
+
+export type GrowthStageResult = {
+  curStage: GrowthStage;
+  isPromotion: boolean;
+};

--- a/apps/api/src/plant/types/plant.types.ts
+++ b/apps/api/src/plant/types/plant.types.ts
@@ -1,0 +1,15 @@
+import { Prisma } from 'generated/prisma/client';
+
+export type CreatedNode = {
+  hue: number;
+  size: number;
+  length: number;
+  depth: number;
+  parentId: string;
+  todoId: string;
+  plantId: string;
+};
+
+export type PlantWithNode = Prisma.PlantGetPayload<{
+  include: { plantNodes: true };
+}>;

--- a/apps/api/src/todo/todo.controller.ts
+++ b/apps/api/src/todo/todo.controller.ts
@@ -60,8 +60,8 @@ export class TodoController {
   @Patch(':id/complete')
   async complete(
     @Param('id') id: string,
-    @Body('plantId') plantId: string,
+    @Req() req: Request & { user: RequestUser },
   ): Promise<PlantNode[]> {
-    return await this.todoService.complete(id, plantId);
+    return await this.todoService.complete(id, req.user.id);
   }
 }

--- a/apps/api/src/todo/todo.module.ts
+++ b/apps/api/src/todo/todo.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { TodoService } from './todo.service';
 import { TodoController } from './todo.controller';
 import { GardenModule } from 'src/garden/garden.module';
+import { PlantModule } from 'src/plant/plant.module';
 
 @Module({
-  imports: [GardenModule],
+  imports: [GardenModule, PlantModule],
   controllers: [TodoController],
   providers: [TodoService],
 })

--- a/apps/api/src/todo/todo.service.ts
+++ b/apps/api/src/todo/todo.service.ts
@@ -137,13 +137,14 @@ export class TodoService {
    * Todoを完了し、スコアに応じたノードをPlantに追加する
    *
    * @param {string} todoId - 完了させるTodoのid
-   * @param {string} plantId - ノードを追加するPlantのid
+   * @param {string} userId - 完了したTodoの所有ユーザーのid
    * @returns {PlantNode[]} 生成・保存されたノード配列
    */
-  async complete(todoId: string, plantId: string): Promise<PlantNode[]> {
+  async complete(todoId: string, userId: string): Promise<PlantNode[]> {
     const currentTodo = await this.prismaService.todo.findFirst({
       where: {
         id: todoId,
+        userId,
         startedAt: { not: null },
         completedAt: null,
       },
@@ -161,8 +162,9 @@ export class TodoService {
 
     const score = this.calcScore(completeTodo);
 
-    const selectPlant = await this.prismaService.plant.findUnique({
-      where: { id: plantId },
+    const gardenId = await this.getActiveGardenId(userId);
+    const selectPlant = await this.prismaService.plant.findFirst({
+      where: { gardenId },
       include: { plantNodes: true },
     });
 

--- a/apps/api/src/todo/todo.service.ts
+++ b/apps/api/src/todo/todo.service.ts
@@ -13,37 +13,18 @@ import {
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateTodoDto } from './dto/create-todo.dto';
 import { UpdateTodoDto } from './dto/update-todo.dto';
-import {
-  CompleteTodo,
-  CreatedNode,
-  GrowthStageResult,
-  PlantWithNode,
-  Score,
-} from './types/todo.types';
+import { CompleteTodo, GrowthStageResult, Score } from './types/todo.types';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/client';
 import { GardenService } from 'src/garden/garden.service';
+import { PlantService } from 'src/plant/plant.service';
 
 @Injectable()
 export class TodoService {
   constructor(
     private readonly prismaService: PrismaService,
     private readonly gardenService: GardenService,
+    private readonly plantService: PlantService,
   ) {}
-
-  /**
-   * 指定された範囲内のランダムな小数を生成する
-   *
-   * @param {number} min - 最小値(含む)
-   * @param {number} max - 最大値(含む)
-   * @returns {number} min以上max以下のランダムな小数
-   * @throws {Error} minがmaxより大きい場合
-   */
-  private random(min: number, max: number): number {
-    if (min > max) {
-      throw new Error('最小値は最大値以下である必要があります');
-    }
-    return Math.random() * (max - min) + min;
-  }
 
   /**
    * Todoの作業時間と目標時間の差分率からスコアランクとノード生成数を算出する
@@ -76,72 +57,6 @@ export class TodoService {
     } else {
       return { rank: TodoScore.D, nodeCount: 1 };
     }
-  }
-
-  /**
-   * 指定された個数の子ノードをランダムな親から生成する
-   *
-   * @param {number} count - 生成するノード数
-   * @param {PlantWithNode} selectPlant - ノードを追加するPlant
-   * @param {string} todoId - ノードの生成元となるTodoのid
-   * @returns {CreatedNode[]} 生成したノード配列
-   */
-  private generateNode(
-    count: number,
-    selectPlant: PlantWithNode,
-    todoId: string,
-  ): CreatedNode[] {
-    const MIN_HUE = 80;
-    const BASE_HUE = 120;
-    const HUE_DECAY_PER_DEPTH = 4;
-    const MIN_SIZE = 3;
-    const MIN_SIZE_RATIO = 0.65;
-    const MAX_SIZE_RATIO = 0.88;
-    const MIN_LENGTH = 5;
-    const MAX_LENGTH = 50;
-    const MIN_LENGTH_RATIO = 0.8;
-    const MAX_LENGTH_RATIO = 1.1;
-
-    const createdNodes: CreatedNode[] = [];
-
-    for (let i = 0; i < count; i++) {
-      const nodeIndex: number = Math.floor(
-        Math.random() * selectPlant.plantNodes.length,
-      );
-      const parentNode: PlantNode = selectPlant.plantNodes[nodeIndex];
-
-      if (!parentNode) {
-        throw new BadRequestException('親ノードが見つかりません。');
-      }
-
-      // ルートノードを親ノードとして生成する場合
-      const parentNodeLength =
-        parentNode.length === null ? MAX_LENGTH : parentNode.length;
-
-      // 子ノードのパラメータは親から継承し、深さに応じて減衰させる
-      const childNode: CreatedNode = {
-        hue: Math.max(
-          MIN_HUE,
-          BASE_HUE - parentNode.depth * HUE_DECAY_PER_DEPTH,
-        ),
-        size: Math.max(
-          MIN_SIZE,
-          parentNode.size * this.random(MIN_SIZE_RATIO, MAX_SIZE_RATIO),
-        ),
-        length: Math.max(
-          MIN_LENGTH,
-          parentNodeLength * this.random(MIN_LENGTH_RATIO, MAX_LENGTH_RATIO),
-        ),
-        depth: parentNode.depth + 1,
-        parentId: parentNode.id,
-        plantId: selectPlant.id,
-        todoId,
-      };
-
-      createdNodes.push(childNode);
-    }
-
-    return createdNodes;
   }
 
   /**
@@ -291,7 +206,7 @@ export class TodoService {
       throw new NotFoundException('Plantが見つかりません。');
     }
 
-    const createNodes = this.generateNode(
+    const createNodes = this.plantService.generateNode(
       score.nodeCount,
       selectPlant,
       currentTodo.id,

--- a/apps/api/src/todo/todo.service.ts
+++ b/apps/api/src/todo/todo.service.ts
@@ -3,17 +3,11 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import {
-  GrowthStage,
-  Plant,
-  PlantNode,
-  Todo,
-  TodoScore,
-} from 'generated/prisma/client';
+import { PlantNode, Todo, TodoScore } from 'generated/prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateTodoDto } from './dto/create-todo.dto';
 import { UpdateTodoDto } from './dto/update-todo.dto';
-import { CompleteTodo, GrowthStageResult, Score } from './types/todo.types';
+import { CompleteTodo, Score } from './types/todo.types';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/client';
 import { GardenService } from 'src/garden/garden.service';
 import { PlantService } from 'src/plant/plant.service';
@@ -57,36 +51,6 @@ export class TodoService {
     } else {
       return { rank: TodoScore.D, nodeCount: 1 };
     }
-  }
-
-  /**
-   * 追加ノード数をもとにPlantの現在の成長段階と昇格有無を算出する
-   *
-   * @param {Plant} selectPlant - 対象Plant
-   * @param {number} addNodeCnt - 追加するノード数
-   * @returns {GrowthStageResult} 現在の成長段階と昇格フラグ
-   */
-  private calcGrowthStage(
-    selectPlant: Plant,
-    addNodeCnt: number,
-  ): GrowthStageResult {
-    const curNodeCnt = selectPlant.nodeCount + addNodeCnt;
-
-    const curStage: GrowthStage =
-      curNodeCnt <= 5
-        ? GrowthStage.SPROUT
-        : curNodeCnt <= 15
-          ? GrowthStage.YOUNG
-          : curNodeCnt <= 30
-            ? GrowthStage.MATURE
-            : GrowthStage.BLOOM;
-
-    const isPromotion: boolean = selectPlant.growthStage !== curStage;
-
-    return {
-      curStage,
-      isPromotion,
-    };
   }
 
   private async getActiveGardenId(userId: string): Promise<string> {
@@ -212,7 +176,10 @@ export class TodoService {
       currentTodo.id,
     );
 
-    const growth = this.calcGrowthStage(selectPlant, score.nodeCount);
+    const growth = this.plantService.calcGrowthStage(
+      selectPlant,
+      score.nodeCount,
+    );
 
     if (growth.isPromotion) {
       // TODO: 成長段階昇格時の特殊演出

--- a/apps/api/src/todo/types/todo.types.ts
+++ b/apps/api/src/todo/types/todo.types.ts
@@ -1,4 +1,4 @@
-import { GrowthStage, TodoScore } from 'generated/prisma/client';
+import { TodoScore } from 'generated/prisma/client';
 
 export type Score = {
   rank?: TodoScore;
@@ -9,9 +9,4 @@ export type CompleteTodo = {
   startedAt: Date;
   completedAt: Date;
   targetDuration: number | null;
-};
-
-export type GrowthStageResult = {
-  curStage: GrowthStage;
-  isPromotion: boolean;
 };

--- a/apps/api/src/todo/types/todo.types.ts
+++ b/apps/api/src/todo/types/todo.types.ts
@@ -1,18 +1,8 @@
-import { GrowthStage, Prisma, TodoScore } from 'generated/prisma/client';
+import { GrowthStage, TodoScore } from 'generated/prisma/client';
 
 export type Score = {
   rank?: TodoScore;
   nodeCount: number;
-};
-
-export type CreatedNode = {
-  hue: number;
-  size: number;
-  length: number;
-  depth: number;
-  parentId: string;
-  todoId: string;
-  plantId: string;
 };
 
 export type CompleteTodo = {
@@ -20,10 +10,6 @@ export type CompleteTodo = {
   completedAt: Date;
   targetDuration: number | null;
 };
-
-export type PlantWithNode = Prisma.PlantGetPayload<{
-  include: { plantNodes: true };
-}>;
 
 export type GrowthStageResult = {
   curStage: GrowthStage;


### PR DESCRIPTION
## 概要
Todoの完了処理(complete())に混在していたPlant成長ロジックをPlantServiceへ分離する。

## 変更内容
- generateNode()をTodoService→PlantServiceへ移動（ヘルパーrandom()・型CreatedNode/PlantWithNodeも追従）
- calcGrowthStage()をTodoService→PlantServiceへ移動（型GrowthStageResultも追従）
- complete()からplantIdパラメータを削除し、認証済みuserIdから本人のTodo検証・Plantの自動解決を行うように変更
  - 副次的に、他人の進行中todoを完了させられる権限不備(IDOR)も合わせて修正

## テスト
- [x] `tsc --noEmit` が通ることを確認
- [x] ローカルでの実際のリクエスト確認は未実施

## レビューポイント
- complete()のPlant解決を`plantId`指定から`userId`起点のアクティブGarden検索に変えた点（1 Garden = 最大1 Plantという現状の実装上の制約に依存している）
- レスポンス型は`PlantNode[]`のまま変更していない（仕様書記載の`{ todo, newNodes, plant }`との不一致は今回スコープ外、別Issue化検討）

## 関連
closes #30
