### PR TITLE
test(api): add mocks to scaffold specs for DI resolution

### DIFF
--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -8,7 +8,7 @@ describe('AuthController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
-      providers: [AuthService],
+      providers: [{ provide: AuthService, useValue: {} }],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -1,12 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { JwtService } from '@nestjs/jwt';
 
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        { provide: PrismaService, useValue: {} },
+        { provide: JwtService, useValue: {} },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);

--- a/apps/api/src/garden/garden.controller.spec.ts
+++ b/apps/api/src/garden/garden.controller.spec.ts
@@ -8,7 +8,7 @@ describe('GardenController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [GardenController],
-      providers: [GardenService],
+      providers: [{ provide: GardenService, useValue: {} }],
     }).compile();
 
     controller = module.get<GardenController>(GardenController);

--- a/apps/api/src/garden/garden.service.spec.ts
+++ b/apps/api/src/garden/garden.service.spec.ts
@@ -1,12 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { GardenService } from './garden.service';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('GardenService', () => {
   let service: GardenService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [GardenService],
+      providers: [GardenService, { provide: PrismaService, useValue: {} }],
     }).compile();
 
     service = module.get<GardenService>(GardenService);

--- a/apps/api/src/plant/plant.controller.spec.ts
+++ b/apps/api/src/plant/plant.controller.spec.ts
@@ -8,7 +8,7 @@ describe('PlantController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PlantController],
-      providers: [PlantService],
+      providers: [{ provide: PlantService, useValue: {} }],
     }).compile();
 
     controller = module.get<PlantController>(PlantController);

--- a/apps/api/src/seed/seed.controller.spec.ts
+++ b/apps/api/src/seed/seed.controller.spec.ts
@@ -8,7 +8,7 @@ describe('SeedController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SeedController],
-      providers: [SeedService],
+      providers: [{ provide: SeedService, useValue: {} }],
     }).compile();
 
     controller = module.get<SeedController>(SeedController);

--- a/apps/api/src/seed/seed.service.spec.ts
+++ b/apps/api/src/seed/seed.service.spec.ts
@@ -1,12 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SeedService } from './seed.service';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('SeedService', () => {
   let service: SeedService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SeedService],
+      providers: [SeedService, { provide: PrismaService, useValue: {} }],
     }).compile();
 
     service = module.get<SeedService>(SeedService);

--- a/apps/api/src/todo/todo.controller.spec.ts
+++ b/apps/api/src/todo/todo.controller.spec.ts
@@ -8,7 +8,7 @@ describe('TodoController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TodoController],
-      providers: [TodoService],
+      providers: [{ provide: TodoService, useValue: {} }],
     }).compile();
 
     controller = module.get<TodoController>(TodoController);

--- a/apps/api/src/todo/todo.service.spec.ts
+++ b/apps/api/src/todo/todo.service.spec.ts
@@ -1,12 +1,20 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TodoService } from './todo.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { GardenService } from 'src/garden/garden.service';
+import { PlantService } from 'src/plant/plant.service';
 
 describe('TodoService', () => {
   let service: TodoService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TodoService],
+      providers: [
+        TodoService,
+        { provide: PrismaService, useValue: {} },
+        { provide: GardenService, useValue: {} },
+        { provide: PlantService, useValue: {} },
+      ],
     }).compile();
 
     service = module.get<TodoService>(TodoService);


### PR DESCRIPTION
## 概要
`nest g` が生成した雛形 spec が依存を解決できず起動に失敗していたため、モックを追加して `npm test` を緑にした。

## 変更内容
- コントローラの spec（auth / garden / plant / seed / todo）— 対象サービスを `{ provide: XxxService, useValue: {} }` に差し替え
- サービスの spec（auth / garden / seed / todo）— テスト対象は実クラスのまま、コンストラクタの依存をモックとして登録
  - `auth.service` … PrismaService, JwtService
  - `garden.service` / `seed.service` … PrismaService
  - `todo.service` … PrismaService, GardenService, PlantService

`plant.controller.spec.ts` は元々通っていたが、他のコントローラ spec と形を揃えるため同じ変更を入れた。#41 で `PlantService` に `PrismaService` を注入した際に落ちるのを先回りで防ぐ意味もある。

## テスト
- [x] `npm test` → 10 suites / 16 tests すべて pass
- [x] `npx tsc --noEmit` → エラーなし
- [x] `npx eslint src` → 指摘なし

## レビューポイント
モックはすべて空オブジェクト。現状のテストが `should be defined` のみでメソッドを1つも呼ばないため、DI が解決できれば十分という判断。実際の振る舞いを検証するモック（`jest.fn()` を持つもの）は、各機能のテストを書く Issue で必要な分だけ足していく。

方針は「テスト対象は実クラス、その先はモック」。コントローラのテストではサービスをモックにし、サービスのテストではサービスを実クラスにして Prisma をモックにする。

## 関連
closes #47
- 起因: #46（jest のモジュール解決修正）
