### PR TITLE
refactor(api/prisma): replace polar coordinates with x/y

### DIFF
--- a/apps/api/prisma/migrations/20260902045123_replace_angle_with_x_and_y/migration.sql
+++ b/apps/api/prisma/migrations/20260902045123_replace_angle_with_x_and_y/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `angle` on the `PlantNode` table. All the data in the column will be lost.
+  - You are about to drop the column `length` on the `PlantNode` table. All the data in the column will be lost.
+  - Added the required column `x` to the `PlantNode` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `y` to the `PlantNode` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "PlantNode" DROP COLUMN "angle",
+DROP COLUMN "length",
+ADD COLUMN     "x" DOUBLE PRECISION NOT NULL,
+ADD COLUMN     "y" DOUBLE PRECISION NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -49,19 +49,19 @@ model User {
 }
 
 model Garden {
-  id           String    @id @default(uuid()) @db.Uuid
+  id           String       @id @default(uuid()) @db.Uuid
   snapshotUrl  String? // v2: スクリーンショット保存用
-  isActive     Boolean   @default(true)
+  isActive     Boolean      @default(true)
   periodType   GardenPeriod
   todos        Todo[] // この期間に作ったTodoという概念
   plants       Plant[] // Garden内の全ネットワークを保持
   plantedSeeds Seed[]
-  userId       String    @db.Uuid
-  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  startedAt    DateTime  @default(now()) @db.Timestamptz(0)
-  endedAt      DateTime? @db.Timestamptz(0) // 期間終了時に日付格納
-  updatedAt    DateTime  @updatedAt @db.Timestamptz(0)
-  createdAt    DateTime  @default(now()) @db.Timestamptz(0)
+  userId       String       @db.Uuid
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  startedAt    DateTime     @default(now()) @db.Timestamptz(0)
+  endedAt      DateTime?    @db.Timestamptz(0) // 期間終了時に日付格納
+  updatedAt    DateTime     @updatedAt @db.Timestamptz(0)
+  createdAt    DateTime     @default(now()) @db.Timestamptz(0)
 }
 
 model Todo {
@@ -109,11 +109,12 @@ model Plant {
 
 model PlantNode {
   id        String      @id @default(uuid()) @db.Uuid
+  // Plant内ローカル座標。
+  x         Float
+  y         Float
   hue       Float
   size      Float
   depth     Int
-  angle     Float? // 親ノードからの角度
-  length    Float? // 親ノードから自ノードまでの距離Ï
   children  PlantNode[] @relation("ParentChildren")
   edgesFrom PlantEdge[] @relation("EdgeFrom")
   edgesTo   PlantEdge[] @relation("EdgeTo")

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -72,10 +72,11 @@ export async function main() {
 
   const devPlantNode = await prisma.plantNode.create({
     data: {
+      x: 0,
+      y: 0,
       hue: 120,
       size: 10,
       depth: 0,
-      length: 30,
       todoId: devTodos.at(1)?.id,
       plantId: devPlant.id,
     },

--- a/apps/api/src/garden/garden.service.ts
+++ b/apps/api/src/garden/garden.service.ts
@@ -91,6 +91,8 @@ export class GardenService {
       // ルートノード生成
       await tx.plantNode.create({
         data: {
+          x: 0,
+          y: 0,
           hue: 120.0,
           size: 20.0,
           depth: 0,

--- a/apps/api/src/plant/plant.service.ts
+++ b/apps/api/src/plant/plant.service.ts
@@ -57,10 +57,6 @@ export class PlantService {
     const MIN_SIZE = 3;
     const MIN_SIZE_RATIO = 0.65;
     const MAX_SIZE_RATIO = 0.88;
-    const MIN_LENGTH = 5;
-    const MAX_LENGTH = 50;
-    const MIN_LENGTH_RATIO = 0.8;
-    const MAX_LENGTH_RATIO = 1.1;
 
     const createdNodes: CreatedNode[] = [];
 
@@ -74,24 +70,22 @@ export class PlantService {
         throw new BadRequestException('親ノードが見つかりません。');
       }
 
-      // ルートノードを親ノードとして生成する場合
-      const parentNodeLength =
-        parentNode.length === null ? MAX_LENGTH : parentNode.length;
-
+      const hue = Math.max(
+        MIN_HUE,
+        BASE_HUE - parentNode.depth * HUE_DECAY_PER_DEPTH,
+      );
+      const size = Math.max(
+        MIN_SIZE,
+        parentNode.size * this.random(MIN_SIZE_RATIO, MAX_SIZE_RATIO),
+      );
+      const angle = this.random(0, Math.PI * 2);
+      const dist = this.random(size + 10, size + 20);
       // 子ノードのパラメータは親から継承し、深さに応じて減衰させる
       const childNode: CreatedNode = {
-        hue: Math.max(
-          MIN_HUE,
-          BASE_HUE - parentNode.depth * HUE_DECAY_PER_DEPTH,
-        ),
-        size: Math.max(
-          MIN_SIZE,
-          parentNode.size * this.random(MIN_SIZE_RATIO, MAX_SIZE_RATIO),
-        ),
-        length: Math.max(
-          MIN_LENGTH,
-          parentNodeLength * this.random(MIN_LENGTH_RATIO, MAX_LENGTH_RATIO),
-        ),
+        x: parentNode.x + dist * Math.cos(angle),
+        y: parentNode.y + dist * Math.sin(angle),
+        hue: hue,
+        size: size,
         depth: parentNode.depth + 1,
         parentId: parentNode.id,
         plantId: selectPlant.id,

--- a/apps/api/src/plant/types/plant.types.ts
+++ b/apps/api/src/plant/types/plant.types.ts
@@ -1,9 +1,10 @@
 import { GrowthStage, Prisma } from 'generated/prisma/client';
 
 export type CreatedNode = {
+  x: number;
+  y: number;
   hue: number;
   size: number;
-  length: number;
   depth: number;
   parentId: string;
   todoId: string;

--- a/apps/web/src/feature/garden/components/GardenCanvas.tsx
+++ b/apps/web/src/feature/garden/components/GardenCanvas.tsx
@@ -9,40 +9,31 @@ interface Coordinate {
 }
 
 /**
- * 描画用にノード群の絶対座標を計算する。（極座標->絶対座標）
+ * Plant内ローカル座標を描画用のキャンバス座標へ平行移動する。
  *
- * @param {PlantNodeData[]} nodes - 極座標のノード群（DB取得時）
- * @returns {Map<string, Coordinate>} 絶対座標のノード群
+ * PlantNode.x/y はルートノードを原点とするPlant内の相対座標。
+ * 描画時にPlantの配置位置を加算して絶対座標にする。
+ * ORIGIN は暫定値で、将来はSeedのx/yに置き換わる。
+ *
+ * @param {PlantNodeData[]} nodes - Plant内ローカル座標のノード群
+ * @returns {Map<string, Coordinate>} キャンバス座標のノード群
  */
 const calcCoord = (nodes: PlantNodeData[]): Map<string, Coordinate> => {
+  const ORIGIN_X = 200;
+  const ORIGIN_Y = 200;
   const coordMap = new Map<string, Coordinate>();
 
-  // ルートノードの計算
+  // ルートノードの存在確認（データ破損検知）
   const root = nodes.find((r) => r.parentId === null);
   if (!root)
     throw new Error(
       "ルートノードが見つかりませんでした。データが破損している可能性があります。",
     );
-  coordMap.set(root.id, {
-    x: 200,
-    y: 200,
-    r: root.size / 2,
-    hue: root.hue,
-  });
 
-  // ルートノード以外の計算
-  const sorted = [...nodes].sort((a, b) => a.depth - b.depth);
-  sorted.forEach((node) => {
-    // ルートスキップ
-    if (node.parentId === null) return;
-    // 親が計算済みか確認
-    const parent = coordMap.get(node.parentId);
-    if (!parent) return;
-
-    if (node.length === null || node.angle === null) return;
+  nodes.forEach((node) => {
     coordMap.set(node.id, {
-      x: parent.x + node.length * Math.cos(node.angle),
-      y: parent.y + node.length * Math.sin(node.angle),
+      x: node.x + ORIGIN_X,
+      y: node.y + ORIGIN_Y,
       r: node.size / 2,
       hue: node.hue,
     });
@@ -67,21 +58,21 @@ export const GardenCanvas = () => {
       viewBox="0 0 400 400"
     >
       {nodesData.map((n, i) => {
-          if(n.parentId === null) return; // ルート除外
-          const from = coordMap.get(n.parentId);
-          const to = coordMap.get(n.id);
-          return (
-            <line
-              key={i}
-              x1={from?.x}
-              y1={from?.y}
-              x2={to?.x}
-              y2={to?.y}
-              stroke={LINECOLOR}
-              strokeWidth={LINESIZE}
-            />
-          );
-        })}
+        if (n.parentId === null) return; // ルート除外
+        const from = coordMap.get(n.parentId);
+        const to = coordMap.get(n.id);
+        return (
+          <line
+            key={i}
+            x1={from?.x}
+            y1={from?.y}
+            x2={to?.x}
+            y2={to?.y}
+            stroke={LINECOLOR}
+            strokeWidth={LINESIZE}
+          />
+        );
+      })}
       {Array.from(coordMap.entries()).map(([id, n]) => (
         <circle
           key={id}

--- a/apps/web/src/feature/garden/mockNodeData.ts
+++ b/apps/web/src/feature/garden/mockNodeData.ts
@@ -10,11 +10,11 @@ export const mockPlant: PlantData = {
     {
       // root node
       id: "nodeId-0",
+      x: 0,
+      y: 0,
       hue: 120,
       size: 50,
       depth: 0,
-      angle: null,
-      length: null,
       parentId: null,
       todoId: null,
       plantId: "plantId-0",
@@ -23,11 +23,11 @@ export const mockPlant: PlantData = {
     {
       // root child node 1
       id: "nodeId-1",
+      x: 0,
+      y: 50,
       hue: 100,
       size: 30,
       depth: 1,
-      angle: Math.PI / 2,
-      length: 50,
       parentId: "nodeId-0",
       todoId: null,
       plantId: "plantId-0",
@@ -36,11 +36,11 @@ export const mockPlant: PlantData = {
     {
       // root child node 2
       id: "nodeId-2",
+      x: 50,
+      y: 100,
       hue: 80,
       size: 50,
       depth: 1,
-      angle: 3 * Math.PI / 4,
-      length: 80,
       parentId: "nodeId-0",
       todoId: null,
       plantId: "plantId-0",

--- a/packages/shared/src/types/plant.ts
+++ b/packages/shared/src/types/plant.ts
@@ -4,11 +4,11 @@ export type SeedType = 'TENDRIL';
 
 export interface PlantNodeData {
   id: string;
+  x: number;
+  y: number;
   hue: number;
   size: number;
   depth: number;
-  angle: number | null;
-  length: number | null;
   parentId: string | null;
   todoId: string | null;
   plantId: string;


### PR DESCRIPTION
## 概要

`PlantNode` の `angle` / `length` を削除し、`x` / `y`（Float・NOT NULL）に置き換えた。
schema からフロントの描画まで一貫して直交座標に統一している。

## 変更内容

- `schema.prisma` + マイグレーション
  `DROP COLUMN angle, length` / `ADD COLUMN x, y DOUBLE PRECISION NOT NULL`
- api
  - `plant.types.ts` — `CreatedNode` の `length` を `x` / `y` に
  - `plant.service.ts` — `generateNode()` が直交座標を返す。`MIN/MAX_LENGTH` 系の定数を削除
  - `garden.service.ts` — ルートノード生成に `x: 0, y: 0`
  - `seed.ts` — 同上
- shared — `PlantNodeData` の `angle` / `length`（nullable）を `x` / `y`（non-null）に
- web
  - `GardenCanvas.tsx` — `calcCoord` の極座標変換を削除。全ノードに配置位置を加算するだけに
  - `mockNodeData.ts` — ルート原点の規約に合わせて `(0,0) / (0,50) / (50,100)`

## テスト

- [x] `npx prisma migrate status` → up to date（11 migrations）
- [x] `npx turbo run lint typecheck test build --force` → 6/6 成功・0 cached
- [x] `npm test` → 10 suites / 16 tests
- [x] `npx prisma db seed` が成功する（ルートを 0,0 に変えた後の再実行）
- [x] `npm run dev` で描画を目視確認する
- [x] CI が緑（この PR 上で確認）

## レビューポイント

**1. `x` / `y` は NOT NULL なので #43 までの暫定値が必要**

`todo.service.ts` の `createManyAndReturn` と `garden.service.ts` の `create` が
実際にノードを永続化しているため、埋める値が無いとコードが通らない。

`generateNode()` が「親の座標 + ランダム方向 × 子サイズ由来の距離」で埋めている。
距離を子の `size` から出しているのは、深くなるほどノードが小さくなり間隔も縮むため。
**#43 で d3-force に丸ごと置き換わる前提の暫定実装。**

**2. 座標系は Plant 内ローカル（ルートが原点）**

`garden.service.ts` / `seed.ts` / `mockNodeData.ts` の3箇所をルート `0, 0` に統一した。
描画時に配置位置を加算する。`GardenCanvas.tsx` の `ORIGIN_X/Y = 200` は暫定値で、
将来は `Seed.x/y` に置き換わる。

**3. `generateNode()` にテストが無い**

`plant.service.spec.ts` は `calcHeights` のみをカバーしている。今回の変更で
`generateNode()` の出力契約が変わったが、テストは追加していない。

暫定座標のロジックは #43 で置換されるため、ここにテストを書いても同時に捨てることになる。
レイアウト工程が確定する #43 で、そちらに対して書く方が正しいと判断した。

**4. 整形差分が約25行混ざっている**

`schema.prisma` の `Garden` モデルと `GardenCanvas.tsx` の `<line>` ブロックは
formatter による整列のみ。`git show --ignore-all-space` で実質差分だけ見られる
（81/77 → 56/52）。`schema.prisma` は21行変わって見えるが実質3行。

## 関連
closes #40
- 後続: #41（着火点選択）/ #42（Forest Fire 延焼）
- 後続: #43（d3-force でレイアウト。本 PR の暫定座標を置き換える）