### PR TITLE
chore(infra): add typecheck script to apps/web

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
     "@algarden/shared": "*",


### PR DESCRIPTION
## 概要

バックエンド側にしかなかったtypecheck scriptをフロント側のpackage.jsonに追加した。

## 変更内容

- 'apps/web' の 'package.json' に typecheck script を追加。

## テスト

- [ ] npx turbo run typecheck が通る
- [ ] web に意図的な型エラーを入れると npx turbo run typecheck が落ちる
- [ ] CI が通る

## レビューポイント

## 関連
closes #61 