### PR TITLE
fix(shared): minimize shared type fields and narrow response payload

### DIFF
--- a/apps/api/src/auth/types/requsetUser.types.ts
+++ b/apps/api/src/auth/types/requsetUser.types.ts
@@ -1,4 +1,13 @@
-export type RequestUser = {
-  id: string;
-  name: string;
-};
+import { UserData } from '@algarden/shared';
+import { Assert, Jsonify } from 'src/common/types/contract.types';
+
+export type RequestUser = { id: string; name: string };
+
+// 共通型の項目が不足していないか
+export type RequestUserContract = Assert<UserData, Jsonify<RequestUser>>;
+
+// 共通型にない項目を余分に転送していないか
+export type RequestUserContractNoExcess = Assert<
+  Jsonify<RequestUser>,
+  UserData
+>;

--- a/apps/api/src/garden/garden.service.ts
+++ b/apps/api/src/garden/garden.service.ts
@@ -8,7 +8,7 @@ import { PrismaClientKnownRequestError } from '@prisma/client/runtime/client';
 import { Garden, Plant, PlantNode } from 'generated/prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { PlantSeedDto } from './dto/plant-seed.dto';
-import { GardenWithPlants } from './types/garden.types';
+import { gardenSelect, GardenWithPlants } from './types/garden.types';
 
 @Injectable()
 export class GardenService {
@@ -17,17 +17,10 @@ export class GardenService {
   // ユーザーのアクティブなGardenを取得する
   async getActive(userId: string): Promise<GardenWithPlants> {
     const garden = await this.prismaService.garden.findFirst({
+      select: gardenSelect,
       where: {
         userId,
         isActive: true,
-      },
-      include: {
-        plants: {
-          include: {
-            plantNodes: true,
-            plantEdges: true,
-          },
-        },
       },
     });
     if (!garden) {

--- a/apps/api/src/garden/types/garden.types.ts
+++ b/apps/api/src/garden/types/garden.types.ts
@@ -1,17 +1,23 @@
 import { GardenData } from '@algarden/shared';
 import { Prisma } from 'generated/prisma/client';
 import { Assert, Jsonify } from 'src/common/types/contract.types';
+import { plantSelect } from 'src/plant/types/plant.types';
 
+export const gardenSelect = {
+  id: true,
+  plants: { select: plantSelect },
+} satisfies Prisma.GardenSelect;
+
+// フロントに送るデータ
 export type GardenWithPlants = Prisma.GardenGetPayload<{
-  include: {
-    plants: {
-      include: {
-        plantNodes: true;
-        plantEdges: true;
-      };
-    };
-  };
+  select: typeof gardenSelect;
 }>;
 
-// 共通型とのtypecheck
+// 共通型の項目が不足していないか
 export type GardenContract = Assert<GardenData, Jsonify<GardenWithPlants>>;
+
+// 共通型にない項目を余分に転送していないか
+export type GardenContractNoExcess = Assert<
+  Jsonify<GardenWithPlants>,
+  GardenData
+>;

--- a/apps/api/src/plant/plant.service.ts
+++ b/apps/api/src/plant/plant.service.ts
@@ -4,7 +4,7 @@ import {
   CreatedNode,
   GrowthStageResult,
   NodeWithChildIds,
-  PlantWithNode,
+  PlantWithNodes,
 } from './types/plant.types';
 
 @Injectable()
@@ -48,7 +48,7 @@ export class PlantService {
    */
   generateNode(
     count: number,
-    selectPlant: PlantWithNode,
+    selectPlant: PlantWithNodes,
     todoId: string,
   ): CreatedNode[] {
     const MIN_HUE = 80;

--- a/apps/api/src/plant/types/plant.types.ts
+++ b/apps/api/src/plant/types/plant.types.ts
@@ -1,5 +1,28 @@
 import { GrowthStage, Prisma } from 'generated/prisma/client';
 
+// フロントに送るPlantの項目。gardenSelectから参照される
+export const plantSelect = {
+  id: true,
+  plantNodes: {
+    select: {
+      id: true,
+      x: true,
+      y: true,
+      hue: true,
+      size: true,
+      parentId: true,
+      createdAt: true,
+    },
+  },
+  plantEdges: {
+    select: {
+      id: true,
+      fromId: true,
+      toId: true,
+    },
+  },
+} satisfies Prisma.PlantSelect;
+
 export type CreatedNode = {
   x: number;
   y: number;
@@ -11,7 +34,8 @@ export type CreatedNode = {
   plantId: string;
 };
 
-export type PlantWithNode = Prisma.PlantGetPayload<{
+// 成長処理用。depthなど画面に送らない項目も必要なためinclude
+export type PlantWithNodes = Prisma.PlantGetPayload<{
   include: { plantNodes: true };
 }>;
 

--- a/apps/api/src/todo/todo.controller.ts
+++ b/apps/api/src/todo/todo.controller.ts
@@ -10,12 +10,13 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { TodoService } from './todo.service';
-import { PlantNode, Todo } from 'generated/prisma/client';
 import { CreateTodoDto } from './dto/create-todo.dto';
 import { UpdateTodoDto } from './dto/update-todo.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { Request } from 'express';
 import { RequestUser } from 'src/auth/types/requsetUser.types';
+import { TodoResponse } from './types/todo.types';
+import { PlantNode, Todo } from 'generated/prisma/client';
 
 @Controller('todos')
 @UseGuards(AuthGuard('jwt'))
@@ -23,7 +24,9 @@ export class TodoController {
   constructor(private readonly todoService: TodoService) {}
 
   @Get()
-  async findAll(@Req() req: Request & { user: RequestUser }): Promise<Todo[]> {
+  async findAll(
+    @Req() req: Request & { user: RequestUser },
+  ): Promise<TodoResponse[]> {
     return await this.todoService.findActiveGardenTodos(req.user.id);
   }
 

--- a/apps/api/src/todo/todo.service.ts
+++ b/apps/api/src/todo/todo.service.ts
@@ -7,7 +7,12 @@ import { PlantNode, Todo, TodoScore } from 'generated/prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateTodoDto } from './dto/create-todo.dto';
 import { UpdateTodoDto } from './dto/update-todo.dto';
-import { CompleteTodo, Score } from './types/todo.types';
+import {
+  CompleteTodo,
+  Score,
+  TodoResponse,
+  todoSelect,
+} from './types/todo.types';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/client';
 import { GardenService } from 'src/garden/garden.service';
 import { PlantService } from 'src/plant/plant.service';
@@ -60,9 +65,10 @@ export class TodoService {
 
   // -----------------------------------------------------------------------------
 
-  async findActiveGardenTodos(userId: string): Promise<Todo[]> {
+  async findActiveGardenTodos(userId: string): Promise<TodoResponse[]> {
     const gardenId = await this.getActiveGardenId(userId);
     return await this.prismaService.todo.findMany({
+      select: todoSelect,
       where: { gardenId },
     });
   }

--- a/apps/api/src/todo/types/todo.types.ts
+++ b/apps/api/src/todo/types/todo.types.ts
@@ -1,5 +1,5 @@
 import { TodoData } from '@algarden/shared';
-import { Todo, TodoScore } from 'generated/prisma/client';
+import { Prisma, TodoScore } from 'generated/prisma/client';
 import { Assert, Jsonify } from 'src/common/types/contract.types';
 
 export type Score = {
@@ -13,5 +13,23 @@ export type CompleteTodo = {
   targetDuration: number | null;
 };
 
-// 共通型とのtypecheck
-export type TodoContract = Assert<TodoData, Jsonify<Todo>>;
+export const todoSelect = {
+  id: true,
+  title: true,
+  isCompleted: true,
+  targetDuration: true,
+  score: true,
+  startedAt: true,
+  completedAt: true,
+} satisfies Prisma.TodoSelect;
+
+// フロントに送るデータ
+export type TodoResponse = Prisma.TodoGetPayload<{
+  select: typeof todoSelect;
+}>;
+
+// 共通型の項目が不足していないか
+export type TodoContract = Assert<TodoData, Jsonify<TodoResponse>>;
+
+// 共通型にない項目を余分に転送していないか
+export type TodoContractNoExcess = Assert<Jsonify<TodoResponse>, TodoData>;

--- a/packages/shared/src/types/garden.ts
+++ b/packages/shared/src/types/garden.ts
@@ -1,10 +1,6 @@
 import type { PlantData } from "./plant";
 
-export type GardenPeriod = "MONTHLY";
-
 export interface GardenData {
   id: string;
-  isActive: boolean;
-  periodType: GardenPeriod;
   plants: PlantData[];
 }

--- a/packages/shared/src/types/plant.ts
+++ b/packages/shared/src/types/plant.ts
@@ -1,6 +1,8 @@
-export type GrowthStage = "SPROUT" | "YOUNG" | "MATURE" | "BLOOM";
-
-export type SeedType = "TENDRIL";
+export interface PlantData {
+  id: string;
+  plantNodes: PlantNodeData[];
+  plantEdges: PlantEdgeData[];
+}
 
 export interface PlantNodeData {
   id: string;
@@ -8,27 +10,12 @@ export interface PlantNodeData {
   y: number;
   hue: number;
   size: number;
-  depth: number;
   parentId: string | null;
-  todoId: string | null;
-  plantId: string;
-  createdAt: string;
-}
-
-export interface PlantData {
-  id: string;
-  growthStage: GrowthStage;
-  nodeCount: number;
-  seedId: string;
-  gardenId: string;
-  plantNodes: PlantNodeData[];
-  plantEdges: PlantEdgeData[];
+  createdAt: string; // Nodeフォーカス時に表示
 }
 
 export interface PlantEdgeData {
   id: string;
-  plantId: string;
   fromId: string;
   toId: string;
-  createdAt: string;
 }

--- a/packages/shared/src/types/todo.ts
+++ b/packages/shared/src/types/todo.ts
@@ -6,9 +6,6 @@ export interface TodoData {
   isCompleted: boolean;
   targetDuration: number | null;
   score: TodoScore | null;
-  gardenId: string;
-  userId: string;
   startedAt: string | null;
   completedAt: string | null;
-  createdAt: string;
 }


### PR DESCRIPTION
## 概要

共通型をフロントが使う項目だけに絞り、`select` で実際の転送内容も型に揃える。

Closes #60

## 変更点

- 共通型から未使用カラムを削除（`GardenData` / `PlantData` / `PlantNodeData` / `PlantEdgeData` / `TodoData`）
- `gardenSelect` / `todoSelect` / `plantSelect` を定義し、クエリと型を同じ定数から導出
- 契約に逆方向の `Assert` を追加。共通型にない項目を返していないかも検知するようにした

## レビューしてほしい点

- **`GardenData` が `{ id, plants }` まで痩せた。** `id` は現在web未使用だが
  `POST /gardens/:id/plant` で必要になるため残している
- **`PlantWithNodes` は `include` のまま。** 成長処理が `depth` を必要とするため、
  レスポンス用の `plantSelect` とは別物として分けた
- **`startTimer` / `complete` の戻り値は絞っていない。** 別Issueで `void` にする予定のため、
  ここで `select` を書いても捨てることになる

## 確認

`npx turbo run lint typecheck test build --force` が 7/7 通過
