### PR TITLE
fix(web/todo): reflect completion state on TodoItem checkbox

### DIFF
--- a/apps/web/src/feature/todo/api/completeTodo.ts
+++ b/apps/web/src/feature/todo/api/completeTodo.ts
@@ -5,6 +5,9 @@ export const completeTodo = async (id: string): Promise<PlantNodeData[]> => {
   const res = await apiClient(`/todos/${id}/complete`, {
     method: "PATCH",
   });
-  if (!res.ok) throw new Error("Failed to fetch todo");
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.message ?? "Failed to complete todo");
+  }
   return res.json();
 };

--- a/apps/web/src/feature/todo/api/getTodos.ts
+++ b/apps/web/src/feature/todo/api/getTodos.ts
@@ -3,6 +3,9 @@ import { apiClient } from "../../../api/client";
 
 export const getTodos = async (): Promise<TodoData[]> => {
   const res = await apiClient("/todos");
-  if (!res.ok) throw new Error("Failed to fetch todos");
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.message ?? "Failed to fetch todos");
+  }
   return res.json();
 };

--- a/apps/web/src/feature/todo/api/queries.ts
+++ b/apps/web/src/feature/todo/api/queries.ts
@@ -1,8 +1,4 @@
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "../../../api/queryKeys";
 import { getTodos } from "./getTodos";
 import { completeTodo } from "./completeTodo";
@@ -23,7 +19,7 @@ export const useStartTodo = () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.todos });
     },
     onError: (e) => {
-      console.error("Failed to start: " + e);
+      alert(e.message || "エラーが発生しました。");
     },
   });
 };
@@ -38,7 +34,7 @@ export const useCompleteTodo = () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.gardens });
     },
     onError: (e) => {
-      console.error("Failed to complete: " + e);
+      alert(e.message || "エラーが発生しました。");
     },
   });
 };

--- a/apps/web/src/feature/todo/api/startTodo.ts
+++ b/apps/web/src/feature/todo/api/startTodo.ts
@@ -5,6 +5,9 @@ export const startTodo = async (id: string): Promise<TodoData> => {
   const res = await apiClient(`/todos/${id}/start`, {
     method: "PATCH",
   });
-  if (!res.ok) throw new Error("Failed to start todo");
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.message ?? "Failed to start todo");
+  }
   return res.json();
 };

--- a/apps/web/src/feature/todo/components/TodoItem.tsx
+++ b/apps/web/src/feature/todo/components/TodoItem.tsx
@@ -1,6 +1,7 @@
 type Props = {
   title: string;
   targetDuration: number | null;
+  isCompleted: boolean;
   onComplete: () => void;
   onStart: () => void;
 };
@@ -8,6 +9,7 @@ type Props = {
 export const TodoItem = ({
   title,
   targetDuration,
+  isCompleted,
   onComplete,
   onStart,
 }: Props) => {
@@ -15,7 +17,7 @@ export const TodoItem = ({
     <div className="flex text-lg text-bold font-sans mx-4 my-2 border-b-1 border-purple-500 grid grid-cols-4 gap-1">
       {/* check box */}
       <div className="m-auto">
-        <input type="checkbox" onChange={onComplete} />
+        <input type="checkbox" checked={isCompleted} onChange={onComplete} />
       </div>
 
       {/* title */}

--- a/apps/web/src/feature/todo/components/TodoList.tsx
+++ b/apps/web/src/feature/todo/components/TodoList.tsx
@@ -18,6 +18,7 @@ export const TodoList = () => {
             key={todo.id}
             title={todo.title}
             targetDuration={todo.targetDuration}
+            isCompleted={todo.isCompleted}
             onComplete={() => completeMutation.mutate(todo.id)}
             onStart={() => startMutation.mutate(todo.id)}
           />


### PR DESCRIPTION
## 概要

TodoItem のチェックボックスにサーバーの完了状態を反映し、失敗をユーザーに見せるようにする。

## 変更内容
- `TodoList` から `isCompleted` を渡し、チェックボックスを制御コンポーネント化
- `getTodos` / `startTodo` / `completeTodo` でエラーレスポンスの `message` を拾う
- mutation の `onError` を `console.error` から `alert` に変更

## テスト
- [x] `npx turbo run lint typecheck test build --force` が 7/7 通過
- [x] 完了済み Todo がリロード後もチェック付きで表示される
- [x] start を押さずにチェックすると、チェックが戻り alert が出る
- [x] 完了済み Todo の start を押すと alert が出る

## レビューポイント
- 失敗時にチェックを戻す処理は入れていない。`checked` がサーバー状態だけを見ているため、楽観的にチェックが付かず React が controlled input を戻す
- 完了済み Todo を `disabled` にしていない。押すとサーバーの 400 が alert に出るので、押せない理由が伝わる方を優先した
- `alert` を queries 層に置いた。#68 で画面内表示に置き換わる想定の暫定対応

## 関連
closes #59
